### PR TITLE
UI improvement

### DIFF
--- a/src/components/SupportedToken.tsx
+++ b/src/components/SupportedToken.tsx
@@ -103,17 +103,28 @@ export function SupportedToken(props: { token: string }) {
                     min: '1250000000000000000000',
                     max: '1250000000000000000000',
                 })),
-            account.viewFunction({
-                contractId: token,
-                methodName: 'storage_balance_of',
-                args: {
-                    account_id: contractAccountId.value,
-                },
-            }),
+            account
+                .viewFunction({
+                    contractId: token,
+                    methodName: 'storage_balance_of',
+                    args: {
+                        account_id: contractAccountId.value,
+                    },
+                })
+                .then((balance) => {
+                    if (balance === null) {
+                        return {
+                            total: '0',
+                            available: '0',
+                        };
+                    }
+
+                    return balance;
+                }),
         ]);
 
         const requiredStorageDeposit = new BN(storageBalanceBounds.min).sub(
-            new BN(storageBalanceOf)
+            new BN(storageBalanceOf.total)
         );
 
         if (requiredStorageDeposit.gt(new BN(0))) {

--- a/src/components/SupportedToken.tsx
+++ b/src/components/SupportedToken.tsx
@@ -55,7 +55,6 @@ export function SupportedToken(props: { token: string }) {
                     account_id: contractAccountId.value,
                 },
             });
-
             if (lowerBound < 0 || parseFloat(balance) > lowerBound) {
                 setLowerBound(parseFloat(balance));
             }
@@ -94,11 +93,16 @@ export function SupportedToken(props: { token: string }) {
         const transactions: Array<Optional<Transaction, 'signerId'>> = [];
 
         const [storageBalanceBounds, storageBalanceOf] = await Promise.all([
-            account.viewFunction({
-                contractId: token,
-                methodName: 'storage_balance_bounds',
-                args: {},
-            }),
+            account
+                .viewFunction({
+                    contractId: token,
+                    methodName: 'storage_balance_bounds',
+                    args: {},
+                })
+                .catch(() => ({
+                    min: '1250000000000000000000',
+                    max: '1250000000000000000000',
+                })),
             account.viewFunction({
                 contractId: token,
                 methodName: 'storage_balance_of',

--- a/src/components/SupportedToken.tsx
+++ b/src/components/SupportedToken.tsx
@@ -99,10 +99,16 @@ export function SupportedToken(props: { token: string }) {
                     methodName: 'storage_balance_bounds',
                     args: {},
                 })
-                .catch(() => ({
-                    min: '1250000000000000000000',
-                    max: '1250000000000000000000',
-                })),
+                .catch((err: unknown) => {
+                    if (['aurora', 'usn'].includes(token)) {
+                        return {
+                            min: '0',
+                            max: '0',
+                        };
+                    }
+
+                    throw err;
+                }),
             account
                 .viewFunction({
                     contractId: token,

--- a/src/pages/Contract/tokens.tsx
+++ b/src/pages/Contract/tokens.tsx
@@ -52,8 +52,11 @@ export function ContractTokens() {
                         const input = (e.target as HTMLInputElement).value;
 
                         try {
-                            supportedTokenListFormat.parse(JSON.parse(input));
-                            setSupportedTokenList(input);
+                            const supportedTokenList =
+                                supportedTokenListFormat.parse(eval(input));
+                            setSupportedTokenList(
+                                JSON.stringify(supportedTokenList, null, 4)
+                            );
                         } catch (err: unknown) {
                             // dont save invalid json
                         }

--- a/src/pages/Contract/tokens.tsx
+++ b/src/pages/Contract/tokens.tsx
@@ -2,12 +2,33 @@ import React from 'preact/compat';
 import { z } from 'zod';
 import { SupportedToken } from '../../components/SupportedToken';
 
+const supportedTokenListFormat = z.array(
+    z.union([
+        z.string(),
+        z.object({
+            id: z.string(),
+        }),
+    ])
+);
+
 export function ContractTokens() {
     const [supportedTokenList, setSupportedTokenList] = React.useState<string>(
         localStorage.getItem('supportedTokenList') || '[]'
     );
 
-    const tokens = z.array(z.string()).parse(JSON.parse(supportedTokenList));
+    const parsedSupportedTokenList = supportedTokenListFormat.parse(
+        JSON.parse(supportedTokenList)
+    );
+
+    const tokens = parsedSupportedTokenList
+        .map((token) => {
+            if (typeof token === 'string') {
+                return token;
+            }
+
+            return token.id;
+        })
+        .filter((token_id) => token_id !== 'near');
 
     React.useEffect(() => {
         localStorage.setItem('supportedTokenList', supportedTokenList);
@@ -22,24 +43,26 @@ export function ContractTokens() {
                 >
                     Supported Token List (JSON stringified array)
                 </label>
-                <input
+                <textarea
                     id='supportedTokenList'
                     type='text'
                     class='bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500'
                     placeholder='JSON stringify array of supported tokens'
-                    value={supportedTokenList}
                     onInput={(e) => {
                         const input = (e.target as HTMLInputElement).value;
 
                         try {
-                            JSON.parse(input);
+                            supportedTokenListFormat.parse(JSON.parse(input));
                             setSupportedTokenList(input);
                         } catch (err: unknown) {
                             // dont save invalid json
                         }
                     }}
+                    rows={10}
                     required
-                />
+                >
+                    {supportedTokenList}
+                </textarea>
             </div>
             <div class='my-5'>
                 <h2 class='text-2xl font-semibold text-gray-900 dark:text-white'>


### PR DESCRIPTION
## Changes

### Added support to different format in token list

Now token list can support both "string", or "object with id value as string", example:
```json
[
    {
        "id": "aa-harvest-moon.near"
    },
    "token.sweat"
]
```

---

### Added support for improper JSON format

Now token list can support improper JSON format, it will automatically save the improper JSON format as a proper JSON format. The error it can fix includes: 
- Turning key value of dictionary to become quoted string
- Removing trailing comma in last line

Example:
```javascript
[
    {
        id: "aa-harvest-moon.near",
    },
    "token.sweat",
]
```

the above input will be converted to the following after save:
```json
[
    {
        "id": "aa-harvest-moon.near"
    },
    "token.sweat"
]
```

---

### Added support for Aurora and USN token

Aurora and USN special case were taken care by the code now